### PR TITLE
캡슐 목록 Firebase 연동

### DIFF
--- a/SpaceCapsule/SpaceCapsule.xcodeproj/project.pbxproj
+++ b/SpaceCapsule/SpaceCapsule.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		288A8EFF292360BC000229D2 /* CapsuleDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288A8EFE292360BC000229D2 /* CapsuleDetailCoordinator.swift */; };
 		288A8F03292362CC000229D2 /* CapsuleAddCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288A8F02292362CC000229D2 /* CapsuleAddCoordinator.swift */; };
 		288A8F0529236505000229D2 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288A8F0429236505000229D2 /* AppCoordinator.swift */; };
+		28A700BB29358F0F0049FAF8 /* GeoPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A700BA29358F0F0049FAF8 /* GeoPoint.swift */; };
 		28C8C97C292DC360005615BB /* SortPolicySelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C8C97B292DC35F005615BB /* SortPolicySelectionViewController.swift */; };
 		28C8C97E292DC371005615BB /* SortPolicySelectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C8C97D292DC371005615BB /* SortPolicySelectionViewModel.swift */; };
 		28C8C980292DC382005615BB /* SortPolicySelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C8C97F292DC382005615BB /* SortPolicySelectionCoordinator.swift */; };
@@ -253,6 +254,10 @@
 		288A8EFE292360BC000229D2 /* CapsuleDetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapsuleDetailCoordinator.swift; sourceTree = "<group>"; };
 		288A8F02292362CC000229D2 /* CapsuleAddCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapsuleAddCoordinator.swift; sourceTree = "<group>"; };
 		288A8F0429236505000229D2 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		28A700B52934E4C30049FAF8 /* SpaceCapsule.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = SpaceCapsule.app; path = "/Users/pyj/Desktop/workplace/membership/SpaceCapsule/iOS01-Capsule/SpaceCapsule/build/Debug-iphoneos/SpaceCapsule.app"; sourceTree = "<absolute>"; };
+		28A700B62934E4C30049FAF8 /* SpaceCapsuleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = SpaceCapsuleTests.xctest; path = "/Users/pyj/Desktop/workplace/membership/SpaceCapsule/iOS01-Capsule/SpaceCapsule/build/Debug-iphoneos/SpaceCapsuleTests.xctest"; sourceTree = "<absolute>"; };
+		28A700B72934E4C30049FAF8 /* SpaceCapsuleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = SpaceCapsuleUITests.xctest; path = "/Users/pyj/Desktop/workplace/membership/SpaceCapsule/iOS01-Capsule/SpaceCapsule/build/Debug-iphoneos/SpaceCapsuleUITests.xctest"; sourceTree = "<absolute>"; };
+		28A700BA29358F0F0049FAF8 /* GeoPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoPoint.swift; sourceTree = "<group>"; };
 		28C8C97B292DC35F005615BB /* SortPolicySelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortPolicySelectionViewController.swift; sourceTree = "<group>"; };
 		28C8C97D292DC371005615BB /* SortPolicySelectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortPolicySelectionViewModel.swift; sourceTree = "<group>"; };
 		28C8C97F292DC382005615BB /* SortPolicySelectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortPolicySelectionCoordinator.swift; sourceTree = "<group>"; };
@@ -261,9 +266,6 @@
 		4A05D0EB2924C04200A2EF50 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		4A05D1042925CF2A00A2EF50 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		4A1FEFF7292F1F1200A935BB /* CustomAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAnnotation.swift; sourceTree = "<group>"; };
-		4A2449C829349F77000EE58C /* SpaceCapsule.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = SpaceCapsule.app; path = "/Users/jisu/Desktop/Boostcamp/Membership/Git/iOS01-Capsule/SpaceCapsule/build/Debug-iphoneos/SpaceCapsule.app"; sourceTree = "<absolute>"; };
-		4A2449C929349F77000EE58C /* SpaceCapsuleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = SpaceCapsuleTests.xctest; path = "/Users/jisu/Desktop/Boostcamp/Membership/Git/iOS01-Capsule/SpaceCapsule/build/Debug-iphoneos/SpaceCapsuleTests.xctest"; sourceTree = "<absolute>"; };
-		4A2449CA29349F77000EE58C /* SpaceCapsuleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = SpaceCapsuleUITests.xctest; path = "/Users/jisu/Desktop/Boostcamp/Membership/Git/iOS01-Capsule/SpaceCapsule/build/Debug-iphoneos/SpaceCapsuleUITests.xctest"; sourceTree = "<absolute>"; };
 		4A9E9146292A2A5A00B7CC5C /* CLLocationManager+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocationManager+Rx.swift"; sourceTree = "<group>"; };
 		4A9E9148292A383900B7CC5C /* MKMapView+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MKMapView+Rx.swift"; sourceTree = "<group>"; };
 		4AF16AE6292B1F8400787C5C /* CustomAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAnnotationView.swift; sourceTree = "<group>"; };
@@ -737,6 +739,7 @@
 			children = (
 				0DB746AD292DF8F6005FF249 /* Capsule.swift */,
 				0DCEED302932101B006EB2B4 /* UserInfo.swift */,
+				28A700BA29358F0F0049FAF8 /* GeoPoint.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -817,7 +820,7 @@
 				0D707D5429222BEB00380B14 /* FirebaseStorage */,
 			);
 			productName = SpaceCapsule;
-			productReference = 4A2449C829349F77000EE58C /* SpaceCapsule.app */;
+			productReference = 28A700B52934E4C30049FAF8 /* SpaceCapsule.app */;
 			productType = "com.apple.product-type.application";
 		};
 		0D6CA346292216A400E02393 /* SpaceCapsuleTests */ = {
@@ -835,7 +838,7 @@
 			);
 			name = SpaceCapsuleTests;
 			productName = SpaceCapsuleTests;
-			productReference = 4A2449C929349F77000EE58C /* SpaceCapsuleTests.xctest */;
+			productReference = 28A700B62934E4C30049FAF8 /* SpaceCapsuleTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		0D6CA350292216A400E02393 /* SpaceCapsuleUITests */ = {
@@ -853,7 +856,7 @@
 			);
 			name = SpaceCapsuleUITests;
 			productName = SpaceCapsuleUITests;
-			productReference = 4A2449CA29349F77000EE58C /* SpaceCapsuleUITests.xctest */;
+			productReference = 28A700B72934E4C30049FAF8 /* SpaceCapsuleUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 /* End PBXNativeTarget section */
@@ -1009,6 +1012,7 @@
 				288A8ED529235C6F000229D2 /* CapsuleCreateViewController.swift in Sources */,
 				0DCEED3529324188006EB2B4 /* LocationError.swift in Sources */,
 				288A8EC629235BBD000229D2 /* CapsuleMapViewModel.swift in Sources */,
+				28A700BB29358F0F0049FAF8 /* GeoPoint.swift in Sources */,
 				0D77D7C9292B5D490038D054 /* SelectButton.swift in Sources */,
 				0DD83D11292F2EC80020F15C /* UIViewController+.swift in Sources */,
 				288A8EEA29235FF1000229D2 /* CapsuleCloseViewModel.swift in Sources */,

--- a/SpaceCapsule/SpaceCapsule/Manager/Firebase/FirestoreManager.swift
+++ b/SpaceCapsule/SpaceCapsule/Manager/Firebase/FirestoreManager.swift
@@ -87,4 +87,35 @@ class FirestoreManager {
                 }
             }
     }
+    // TODO: FBAuthError 이름 바꾸기
+    func fetchCapsuleList(of uid: String) -> Observable<[Capsule]> {
+        return Observable.create { emitter in
+            self.database.collection("capsules").whereField("userId", isEqualTo: uid).getDocuments { querySnapshot, error in
+                print("a")
+                if let error = error {
+                    print("Error Snapshot: \(error)")
+                    emitter.onError(error)
+                    return
+                } else {
+                    guard let snapshots = querySnapshot?.documents else {
+                        print("Error Snapshot: \(FBAuthError.noSnapshot)")
+                        emitter.onError(FBAuthError.noSnapshot)
+                        return
+                    }
+                    var capsuleList: [Capsule] = []
+                    for snapshot in snapshots {
+                        guard let capsule = self.dictionaryToObject(type: Capsule.self, dictionary: snapshot.data()) else {
+                            print("Error Capsule: \(FBAuthError.decodeError)")
+                            emitter.onError(FBAuthError.decodeError)
+                            return
+                        }
+                        capsuleList.append(capsule)
+                    }
+                    emitter.onNext(capsuleList)
+                    // emitter.onCompleted() 이건 컴플리트 날릴 필요 없을 듯, 왜냐면 캡슐 목록 새로고침 기능 생길 가능성.
+                }
+            }
+            return Disposables.create { }
+        }
+    }
 }

--- a/SpaceCapsule/SpaceCapsule/Model/Capsule.swift
+++ b/SpaceCapsule/SpaceCapsule/Model/Capsule.swift
@@ -6,6 +6,11 @@
 //
 
 import Foundation
+import FirebaseFirestore
+
+protocol DocumentSerializable {
+    init?(dictionary: [String: Any])
+}
 
 struct Capsule: CustomCodable {
     var uuid: String = UUID().uuidString
@@ -39,14 +44,33 @@ struct Capsule: CustomCodable {
     }
 }
 
-struct GeoPoint: CustomCodable {
-    let latitude: Double
-    let longitude: Double
-
-    var dictData: [String: Any] {
-        [
-            "latitude": latitude,
-            "longitude": longitude,
-        ]
+extension Capsule: DocumentSerializable {
+    init?(dictionary: [String: Any]) {
+        guard let uuid = dictionary["uuid"] as? String,
+              let userId = dictionary["userId"] as? String,
+              let images = dictionary["images"] as? [String],
+              let title = dictionary["title"] as? String,
+              let description = dictionary["description"] as? String,
+              let address = dictionary["address"] as? String,
+              let simpleAddress = dictionary["simpleAddress"] as? String,
+              let geopointDict = dictionary["geopoint"] as? NSMutableDictionary,
+              let memoryDate = dictionary["memoryDate"] as? Timestamp,
+              let closedDate = dictionary["closedDate"] as? Timestamp,
+              let openCount = dictionary["openCount"] as? Int
+        else {
+            return nil
+        }
+        guard let latitude = geopointDict["latitude"] as? Double,
+              let longitude = geopointDict["longitude"] as? Double else {
+            print("nsdict decode error")
+            return nil
+        }
+        
+        self.init(uuid: uuid, userId: userId, images: images, title: title,
+                  description: description, address: address, simpleAddress: simpleAddress,
+                  geopoint: GeoPoint(latitude: latitude, longitude: longitude), memoryDate: memoryDate.dateValue(),
+                  closedDate: closedDate.dateValue(), openCount: openCount
+        )
     }
+
 }

--- a/SpaceCapsule/SpaceCapsule/Model/GeoPoint.swift
+++ b/SpaceCapsule/SpaceCapsule/Model/GeoPoint.swift
@@ -1,0 +1,21 @@
+//
+//  GeoPoint.swift
+//  SpaceCapsule
+//
+//  Created by young june Park on 2022/11/29.
+//
+
+import Foundation
+import FirebaseFirestore
+
+struct GeoPoint: CustomCodable {
+    let latitude: Double
+    let longitude: Double
+    
+    var dictData: [String: Any] {
+        [
+            "latitude": latitude,
+            "longitude": longitude,
+        ]
+    }
+}

--- a/SpaceCapsule/SpaceCapsule/Resources/FrameResource.swift
+++ b/SpaceCapsule/SpaceCapsule/Resources/FrameResource.swift
@@ -46,7 +46,8 @@ enum FrameResource {
     static let shadowOffset: CGSize = .init(width: 4, height: 4)
     static let shadowRadius: CGFloat = 4
     static let shadowOpacity: Float = 0.25
-
+    
+    static let openableImageScale: CGFloat = 1.0
     static let closedImageScale: CGFloat = 0.5
     static let closedIconSize: CGFloat = 50.0
     static let closedDateOffset: CGFloat = 10.0

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListView.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListView.swift
@@ -17,6 +17,7 @@ final class CapsuleListView: UIView, BaseView {
         button.setImage(.sort, for: .normal)
         button.tintColor = .themeBlack
         button.semanticContentAttribute = .forceRightToLeft
+        button.contentHorizontalAlignment = .leading
         return button
     }()
 

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListViewController.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListViewController.swift
@@ -46,6 +46,7 @@ final class CapsuleListViewController: UIViewController, BaseViewController {
         
         viewModel.input.sortPolicy
             .withLatestFrom(viewModel.input.capsuleCellModels, resultSelector: { sortPolicy, capsuleCellModels in
+                self.applyBarButton(sortPolicy: sortPolicy)
                 self.viewModel?.sort(capsuleCellModels: capsuleCellModels, by: sortPolicy)
             })
             .bind(onNext: {})
@@ -79,6 +80,13 @@ final class CapsuleListViewController: UIViewController, BaseViewController {
         let sortBarButton = UIBarButtonItem(customView: capsuleListView.sortBarButtonItem)
         sortBarButton.customView?.isUserInteractionEnabled = true
         navigationItem.rightBarButtonItem = sortBarButton
+    }
+    
+    private func applyBarButton(sortPolicy: SortPolicy) {
+        if let barItem = self.navigationItem.rightBarButtonItem,
+           let button = barItem.customView as? UIButton {
+            button.setTitle(sortPolicy.description, for: .normal)
+        }
     }
 }
 

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListViewController.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListViewController.swift
@@ -31,7 +31,6 @@ final class CapsuleListViewController: UIViewController, BaseViewController {
         configureCollectionView()
         bind()
         viewModel?.fetchCapsuleList()
-        viewModel?.input.sortPolicy.onNext(.nearest)
     }
     
     func bind() {

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListViewController.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListViewController.swift
@@ -30,7 +30,7 @@ final class CapsuleListViewController: UIViewController, BaseViewController {
         addSortBarButton()
         configureCollectionView()
         bind()
-        viewModel?.fetchCapsules()
+        viewModel?.fetchCapsuleList()
         viewModel?.input.sortPolicy.onNext(.nearest)
     }
     

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListViewModel.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListViewModel.swift
@@ -14,96 +14,6 @@ final class CapsuleListViewModel: BaseViewModel {
     var disposeBag = DisposeBag()
     var coordinator: CapsuleListCoordinator?
     private let currentLocation = CLLocationCoordinate2D(latitude: 37.582867, longitude: 126.027869)
-    private let capsuleCellModels: [CapsuleCellModel] = [
-        CapsuleCellModel(uuid: UUID(),
-                         thumbnailImage: .logoWithText,
-                         address: "서울시 광진구",
-                         closedDate: "2017년 1월 1일",
-                         memoryDate: "2017년 1월 1일",
-                         isOpenable: true,
-                         coordinate: CLLocationCoordinate2D(latitude: 37.582897, longitude: 126.027169)
-                        ),
-        CapsuleCellModel(uuid: UUID(),
-                         thumbnailImage: .logoWithText,
-                         address: "서울시 동작구",
-                         closedDate: "2018년 3월 3일",
-                         memoryDate: "2018년 3월 3일",
-                         isOpenable: true,
-                         coordinate: CLLocationCoordinate2D(latitude: 37.582817, longitude: 126.027839)
-                        ),
-        CapsuleCellModel(uuid: UUID(),
-                         thumbnailImage: .logoWithText,
-                         address: "서울시 영등포구",
-                         closedDate: "2019년 7월 2일",
-                         memoryDate: "2019년 7월 2일",
-                         isOpenable: false,
-                         coordinate: CLLocationCoordinate2D(latitude: 37.582857, longitude: 126.027889)
-                        ),
-        CapsuleCellModel(uuid: UUID(),
-                         thumbnailImage: .logoWithText,
-                         address: "서울시 동대문구",
-                         closedDate: "2017년 12월 16일",
-                         memoryDate: "2017년 12월 16일",
-                         isOpenable: true,
-                         coordinate: CLLocationCoordinate2D(latitude: 37.582167, longitude: 126.027369)
-                        ),
-        CapsuleCellModel(uuid: UUID(),
-                         thumbnailImage: .logoWithText,
-                         address: "서울시 은평구",
-                         closedDate: "2019년 10월 11일",
-                         memoryDate: "2019년 10월 11일",
-                         isOpenable: false,
-                         coordinate: CLLocationCoordinate2D(latitude: 37.582267, longitude: 126.026869)
-                        ),
-        CapsuleCellModel(uuid: UUID(),
-                         thumbnailImage: .logoWithText,
-                         address: "서울시 구로구",
-                         closedDate: "2016년 11월 11일",
-                         memoryDate: "2016년 11월 11일",
-                         isOpenable: true,
-                         coordinate: CLLocationCoordinate2D(latitude: 37.581867, longitude: 126.027869)
-                        ),
-        CapsuleCellModel(uuid: UUID(),
-                         thumbnailImage: .logoWithText,
-                         address: "서울시 강서구",
-                         closedDate: "2015년 5월 11일",
-                         memoryDate: "2015년 5월 11일",
-                         isOpenable: false,
-                         coordinate: CLLocationCoordinate2D(latitude: 37.582167, longitude: 126.027069)
-                        ),
-        CapsuleCellModel(uuid: UUID(),
-                         thumbnailImage: .logoWithText,
-                         address: "서울시 강동구",
-                         closedDate: "2022년 11월 10일",
-                         memoryDate: "2022년 11월 10일",
-                         isOpenable: false,
-                         coordinate: CLLocationCoordinate2D(latitude: 37.585867, longitude: 126.025869)
-                        ),
-        CapsuleCellModel(uuid: UUID(),
-                         thumbnailImage: .logoWithText,
-                         address: "서울시 용산구",
-                         closedDate: "2015년 11월 10일",
-                         memoryDate: "2015년 11월 10일",
-                         isOpenable: true,
-                         coordinate: CLLocationCoordinate2D(latitude: 37.582817, longitude: 126.027860)
-                        ),
-        CapsuleCellModel(uuid: UUID(),
-                         thumbnailImage: .logoWithText,
-                         address: "서울시 관악구",
-                         closedDate: "2022년 11월 9일",
-                         memoryDate: "2022년 11월 9일",
-                         isOpenable: true,
-                         coordinate: CLLocationCoordinate2D(latitude: 37.582897, longitude: 126.027069)
-                        ),
-        CapsuleCellModel(uuid: UUID(),
-                         thumbnailImage: .logoWithText,
-                         address: "서울시 서초구",
-                         closedDate: "2022년 11월 8일",
-                         memoryDate: "2022년 11월 8일",
-                         isOpenable: false,
-                         coordinate: CLLocationCoordinate2D(latitude: 37.583867, longitude: 126.029869)
-                        )
-    ]
     var input = Input()
 
     struct Input {
@@ -117,8 +27,35 @@ final class CapsuleListViewModel: BaseViewModel {
 
     private func bind() {}
     
-    func fetchCapsules() {
-        input.capsuleCellModels.onNext(capsuleCellModels)
+    func fetchCapsuleList() {
+        guard let currentUser = FirebaseAuthManager.shared.currentUser else {
+            return
+        }
+      
+        FirestoreManager.shared.fetchCapsuleList(of: currentUser.uid)
+            .withUnretained(self)
+            .subscribe(
+            onNext: { owner, capsuleList in
+                let capsuleCellModels = capsuleList.map { capsule in
+                    return CapsuleCellModel(uuid: capsule.uuid,
+                                            thumbnailImageURL: capsule.images.first,
+                                            address: capsule.simpleAddress,
+                                            closedDate: capsule.closedDate.dateString,
+                                            memoryDate: capsule.memoryDate.dateString,
+                                            coordinate: CLLocationCoordinate2D(
+                                                latitude: capsule.geopoint.latitude,
+                                                longitude: capsule.geopoint.longitude
+                                            )
+                    )
+                }
+                owner.input.capsuleCellModels.onNext(capsuleCellModels)
+            },
+            onError: { error in
+                print(error.localizedDescription)
+            }
+        )
+        .disposed(by: disposeBag)
+        
     }
     
     func sort(capsuleCellModels: [CapsuleCellModel], by sortPolicy: SortPolicy) {

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListViewModel.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListViewModel.swift
@@ -40,8 +40,8 @@ final class CapsuleListViewModel: BaseViewModel {
                     return CapsuleCellModel(uuid: capsule.uuid,
                                             thumbnailImageURL: capsule.images.first,
                                             address: capsule.simpleAddress,
-                                            closedDate: capsule.closedDate.dateString,
-                                            memoryDate: capsule.memoryDate.dateString,
+                                            closedDate: capsule.closedDate,
+                                            memoryDate: capsule.memoryDate,
                                             coordinate: CLLocationCoordinate2D(
                                                 latitude: capsule.geopoint.latitude,
                                                 longitude: capsule.geopoint.longitude
@@ -71,11 +71,11 @@ final class CapsuleListViewModel: BaseViewModel {
             }
         case .latest:
             models = capsuleCellModels.sorted {
-                $0.dateToInt() > $1.dateToInt()
+                $0.memoryDate > $1.memoryDate
             }
         case .oldest:
             models = capsuleCellModels.sorted {
-                $0.dateToInt() < $1.dateToInt()
+                $0.memoryDate < $1.memoryDate
             }
         }
         input.capsuleCellModels.onNext(models)

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListViewModel.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListViewModel.swift
@@ -49,6 +49,7 @@ final class CapsuleListViewModel: BaseViewModel {
                     )
                 }
                 owner.input.capsuleCellModels.onNext(capsuleCellModels)
+                owner.input.sortPolicy.onNext(.nearest)
             },
             onError: { error in
                 print(error.localizedDescription)

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/Components/CapsuleCell.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/Components/CapsuleCell.swift
@@ -83,7 +83,7 @@ final class CapsuleCell: UICollectionViewCell {
             $0.removeFromSuperview()
         }
         if capsuleCellModel.isOpenable == false {
-            applyUnOpenableEffect(closeDate: capsuleCellModel.closedDate)
+            applyUnOpenableEffect(closeDate: capsuleCellModel.closedDate.dateString)
         }
     }
     

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/Components/CapsuleCell.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/Components/CapsuleCell.swift
@@ -78,7 +78,7 @@ final class CapsuleCell: UICollectionViewCell {
             thumbnailImageView.image = .logoWithBG
         }
         
-        descriptionLabel.text = "\(capsuleCellModel.memoryDate)\n\(capsuleCellModel.address)에서"
+        descriptionLabel.text = "\(capsuleCellModel.memoryDate.dateString)\n\(capsuleCellModel.address)에서"
         thumbnailImageView.subviews.forEach {
             $0.removeFromSuperview()
         }

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/Components/CapsuleCell.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/Components/CapsuleCell.swift
@@ -72,7 +72,12 @@ final class CapsuleCell: UICollectionViewCell {
     }
 
     func configure(capsuleCellModel: CapsuleCellModel) {
-        thumbnailImageView.image = capsuleCellModel.thumbnailImage
+        if let thumbnailURL = capsuleCellModel.thumbnailImageURL {
+            thumbnailImageView.kr.setImage(with: thumbnailURL, scale: FrameResource.openableImageScale)
+        } else {
+            thumbnailImageView.image = .logoWithBG
+        }
+        
         descriptionLabel.text = "\(capsuleCellModel.memoryDate)\n\(capsuleCellModel.address)에서"
         thumbnailImageView.subviews.forEach {
             $0.removeFromSuperview()

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/Components/CapsuleCellModel.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/Components/CapsuleCellModel.swift
@@ -9,13 +9,17 @@ import UIKit
 import CoreLocation
 
 struct CapsuleCellModel: Hashable, Equatable {
-    let uuid: UUID
-    let thumbnailImage: UIImage?
+    let uuid: String
+    let thumbnailImageURL: String?
     let address: String
     let closedDate: String
     let memoryDate: String
-    let isOpenable: Bool
     let coordinate: CLLocationCoordinate2D
+    
+    var isOpenable: Bool = {
+        var isOpenable = true
+        return isOpenable
+    }()
     
     static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.uuid == rhs.uuid

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/Components/CapsuleCellModel.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/Components/CapsuleCellModel.swift
@@ -12,8 +12,8 @@ struct CapsuleCellModel: Hashable, Equatable {
     let uuid: String
     let thumbnailImageURL: String?
     let address: String
-    let closedDate: String
-    let memoryDate: String
+    let closedDate: Date
+    let memoryDate: Date
     let coordinate: CLLocationCoordinate2D
     
     var isOpenable: Bool = {
@@ -27,23 +27,6 @@ struct CapsuleCellModel: Hashable, Equatable {
     
     func hash(into hasher: inout Hasher) {
         hasher.combine(uuid)
-    }
-    
-    func dateToInt() -> Int {
-        let arr = memoryDate.split(separator: " ")
-        let year = arr[0].replacingOccurrences(of: "년", with: "")
-        var month = arr[1].replacingOccurrences(of: "월", with: "")
-        var day = arr[2].replacingOccurrences(of: "일", with: "")
-        if month.count == 1 {
-            month = "0" + month
-        }
-        if day.count == 1 {
-            day = "0" + day
-        }
-        guard let result = Int(year + month + day) else {
-            return 0
-        }
-        return result
     }
     
     func distance(from: CLLocationCoordinate2D) -> Double {


### PR DESCRIPTION
## 제출 전 필수 확인 사항:

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코드 컨벤션을 준수하는가?
- [x] 빌드가 되는 코드인가요?
- [x] 버그가 발생하지 않는지 충분히 테스트 해봤나요?

## 작업 내용:

캡슐 목록화면에서 파이어베이스 매니저 메소드를 사용하여,
사용자의 캡슐 목록 불러오기 구현.
rxBinding을 으로 화면 시작 할 때,
파이어 베이스에서 캡슐 목록 가져올 수 있도록 구현

업데이트된 Capsule 모델에 
정렬 로직 적용

- Error 처리
- 사용자 특정 (userId)
- fetchCapsules 메소드 구현
- 캡슐 셀 썸네일 이미지 킹리시버 적용 
- rxBinding
-  Capsule -> CapsuleCellModel로 전환
-  정렬 로직 수정


## 이번에 공들였던 부분:
TimeStam 와 GeoPoint(FirebaseFireStore에 있는 클래스)는
NS 형식이 아니기 때문에 JSONDecoder 로 디코딩 할 수 없는 점이 어려웠다.
따라서 하드하게 디코딩 했다.
