### PR TITLE
상세 화면 지도 및 탭 바 업데이트

### DIFF
--- a/SpaceCapsule/SpaceCapsule/Components/Map/CustomAnnotation.swift
+++ b/SpaceCapsule/SpaceCapsule/Components/Map/CustomAnnotation.swift
@@ -9,7 +9,7 @@ import MapKit
 import UIKit
 
 final class CustomAnnotation: MKPointAnnotation {
-    let uuid: String
+    let uuid: String?
 
     weak var annotationView: CustomAnnotationView?
 
@@ -23,7 +23,7 @@ final class CustomAnnotation: MKPointAnnotation {
         return isOpenable ? .openableCapsule : .unopenableCapsule
     }
 
-    required init(uuid: String, latitude: Double, longitude: Double) {
+    required init(uuid: String?, latitude: Double, longitude: Double) {
         self.uuid = uuid
 
         super.init()

--- a/SpaceCapsule/SpaceCapsule/Manager/LocationManager.swift
+++ b/SpaceCapsule/SpaceCapsule/Manager/LocationManager.swift
@@ -11,7 +11,8 @@ import RxSwift
 
 final class LocationManager {
     static let shared = LocationManager()
-
+    static let openableRange = 100.0
+    
     private init() {}
 
     let core: CLLocationManager = {
@@ -102,6 +103,6 @@ final class LocationManager {
     }
 
     func isOpenable(capsuleCoordinate: CLLocationCoordinate2D) -> Bool {
-        return distance(capsuleCoordinate: capsuleCoordinate) <= 100.0 ? true : false
+        return distance(capsuleCoordinate: capsuleCoordinate) <= LocationManager.openableRange ? true : false
     }
 }

--- a/SpaceCapsule/SpaceCapsule/Manager/LocationManager.swift
+++ b/SpaceCapsule/SpaceCapsule/Manager/LocationManager.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 final class LocationManager {
     static let shared = LocationManager()
-    static let openableRange = 100.0
+    static let openableRange = 10000.0
     
     private init() {}
 

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleAccessCoordinator.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleAccessCoordinator.swift
@@ -35,6 +35,7 @@ final class CapsuleAccessCoordinator: Coordinator {
         let capsuleDetailCoordinator = CapsuleDetailCoordinator(navigationController: navigationController)
         capsuleDetailCoordinator.parent = self
         capsuleDetailCoordinator.capsuleUUID = capsuleCellItem?.uuid
+        
         capsuleDetailCoordinator.start()
 
         children.append(capsuleDetailCoordinator)

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleAccessCoordinator.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleAccessCoordinator.swift
@@ -27,7 +27,6 @@ final class CapsuleAccessCoordinator: Coordinator {
         capsuleOpenCoordinator.capsuleCellItem = capsuleCellItem
         capsuleOpenCoordinator.parent = self
         capsuleOpenCoordinator.start()
-        
         children.append(capsuleOpenCoordinator)
     }
 
@@ -35,9 +34,8 @@ final class CapsuleAccessCoordinator: Coordinator {
         let capsuleDetailCoordinator = CapsuleDetailCoordinator(navigationController: navigationController)
         capsuleDetailCoordinator.parent = self
         capsuleDetailCoordinator.capsuleUUID = capsuleCellItem?.uuid
-        
         capsuleDetailCoordinator.start()
-
+        
         children.append(capsuleDetailCoordinator)
     }
 }

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleDetail/CapsuleDetailCoordinator.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleDetail/CapsuleDetailCoordinator.swift
@@ -33,5 +33,15 @@ final class CapsuleDetailCoordinator: Coordinator {
         capsuleDetailViewModel.fetchCapsule(with: capsuleUUID)
         
         navigationController?.pushViewController(capsuleDetailViewController, animated: true)
+        
+        setupNavigationItem()
+    }
+    
+    private func setupNavigationItem() {
+        navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.themeFont(ofSize: FrameResource.fontSize100) as Any]
+        
+        let backButton = UIBarButtonItem()
+        backButton.title = "목록"
+        navigationController?.navigationBar.topItem?.backBarButtonItem = backButton
     }
 }

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleDetail/CapsuleDetailCoordinator.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleDetail/CapsuleDetailCoordinator.swift
@@ -14,25 +14,30 @@ final class CapsuleDetailCoordinator: Coordinator {
     var navigationController: CustomNavigationController?
     
     var capsuleUUID: String?
-
+    
     init(navigationController: CustomNavigationController?) {
         self.navigationController = navigationController
     }
-
+    
     func start() {
         moveToCapsuleDetail()
     }
-
+    
     func moveToCapsuleDetail() {
         let capsuleDetailViewController = CapsuleDetailViewController()
         let capsuleDetailViewModel = CapsuleDetailViewModel()
-
+        
         capsuleDetailViewModel.coordinator = self
         capsuleDetailViewController.viewModel = capsuleDetailViewModel
         
         capsuleDetailViewModel.fetchCapsule(with: capsuleUUID)
         
         navigationController?.pushViewController(capsuleDetailViewController, animated: true)
+        
+        // MARK: 목록으로 이동
+        if let rootVC = navigationController?.viewControllers.first {
+            navigationController?.viewControllers = [rootVC, capsuleDetailViewController]
+        }
         
         setupNavigationItem()
     }

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleDetail/CapsuleDetailCoordinator.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleDetail/CapsuleDetailCoordinator.swift
@@ -30,7 +30,7 @@ final class CapsuleDetailCoordinator: Coordinator {
         capsuleDetailViewModel.coordinator = self
         capsuleDetailViewController.viewModel = capsuleDetailViewModel
         
-        capsuleDetailViewModel.getCapsule(with: capsuleUUID)
+        capsuleDetailViewModel.fetchCapsule(with: capsuleUUID)
         
         navigationController?.pushViewController(capsuleDetailViewController, animated: true)
     }

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleDetail/CapsuleDetailViewController.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleDetail/CapsuleDetailViewController.swift
@@ -59,6 +59,7 @@ final class CapsuleDetailViewController: UIViewController, BaseViewController {
             .subscribe(onNext: { owner, data in
                 if let capsule = data.first {
                     owner.mainView.updateCapsuleData(capsule: capsule)
+                    owner.setUpNavigationTitle(capsule.title)
                 }
             })
             .disposed(by: disposeBag)
@@ -100,5 +101,9 @@ final class CapsuleDetailViewController: UIViewController, BaseViewController {
         snapshot.appendSections([0])
         snapshot.appendItems(cells, toSection: 0)
         imageDataSource?.apply(snapshot)
+    }
+    
+    private func setUpNavigationTitle(_ title: String) {
+        navigationItem.title = title
     }
 }

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleDetail/CapsuleDetailViewController.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleDetail/CapsuleDetailViewController.swift
@@ -7,6 +7,7 @@
 
 import RxSwift
 import SnapKit
+import MapKit
 import UIKit
 
 final class CapsuleDetailViewController: UIViewController, BaseViewController {
@@ -21,12 +22,13 @@ final class CapsuleDetailViewController: UIViewController, BaseViewController {
         super.viewDidLoad()
         
         applyDataSource()
-        
         bind()
+        viewModel?.input.frameWidth.onNext(view.frame.width)
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        
         scrollView.frame = CGRect(origin: .zero, size: view.frame.size)
         scrollView.backgroundColor = .themeBackground
 

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleDetail/CapsuleDetailViewModel.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleDetail/CapsuleDetailViewModel.swift
@@ -62,6 +62,7 @@ final class CapsuleDetailViewModel: BaseViewModel {
         guard let firstImageURL = capsule.images.first else {
             return
         }
+
         let firstCell = DetailImageCell.Cell(imageURL: firstImageURL,
                                              capsuleInfo: DetailImageCell.CapsuleInfo(address: capsule.simpleAddress,
                                                                                       date: capsule.memoryDate.dateString))
@@ -86,31 +87,27 @@ final class CapsuleDetailViewModel: BaseViewModel {
             if error != nil {
                 return
             }
-            
-            UIGraphicsBeginImageContextWithOptions(snapshot.image.size, true, snapshot.image.scale)
-            snapshot.image.draw(at: .zero)
-
-            let point = snapshot.point(for: center)
-            let annotation = MKPointAnnotation()
-            annotation.coordinate = center
-
-            let annotationView = MKMarkerAnnotationView(annotation: annotation, reuseIdentifier: "")
-
-            annotationView.contentMode = .scaleAspectFit
-            annotationView.bounds = CGRect(x: 0, y: 0, width: 40, height: 40)
-            
-            let rect = CGRect(x: point.x - (annotationView.bounds.width / 2),
-                              y: point.y - (annotationView.bounds.height),
-                              width: annotationView.bounds.width,
-                              height: annotationView.bounds.height)
-
-            annotationView.drawHierarchy(in: rect, afterScreenUpdates: true)
-
-            let drawImage = UIGraphicsGetImageFromCurrentImageContext()
-
-            if let drawImage = drawImage {
+ 
+            if let drawImage = self?.drawAnnotation(with: center, on: snapshot) {
                 self?.output.mapSnapshot.accept([drawImage])
             }
         }
+    }
+    
+    private func drawAnnotation(with center: CLLocationCoordinate2D, on snapshot: MKMapSnapshotter.Snapshot) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(snapshot.image.size, true, snapshot.image.scale)
+        snapshot.image.draw(at: .zero)
+
+        let point = snapshot.point(for: center)
+        let annotation = CustomAnnotation(uuid: nil, latitude: center.latitude, longitude: center.longitude)
+        annotation.isOpenable = true
+        let annotationView = CustomAnnotationView(annotation: annotation, reuseIdentifier: "annotationView")
+        let rect = CGRect(x: point.x - (annotationView.bounds.width / 2),
+                          y: point.y - (annotationView.bounds.height),
+                          width: annotationView.bounds.width,
+                          height: annotationView.bounds.height)
+
+        annotationView.drawHierarchy(in: rect, afterScreenUpdates: true)
+        return UIGraphicsGetImageFromCurrentImageContext()
     }
 }

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleDetail/CapsuleDetailViewModel.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleDetail/CapsuleDetailViewModel.swift
@@ -48,7 +48,7 @@ final class CapsuleDetailViewModel: BaseViewModel {
 
     func fetchCapsuleMap(at coordinate: GeoPoint) {
         let center = CLLocationCoordinate2D(latitude: coordinate.latitude, longitude: coordinate.longitude)
-        let span = MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+        let span = MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005)
 
         let options: MKMapSnapshotter.Options = .init()
         options.region = MKCoordinateRegion(center: center, span: span)
@@ -77,8 +77,8 @@ final class CapsuleDetailViewModel: BaseViewModel {
             annotationView.contentMode = .scaleAspectFit
             annotationView.bounds = CGRect(x: 0, y: 0, width: 40, height: 40)
             
-            let rect = CGRect(x: point.x - annotationView.bounds.width,
-                              y: point.y - annotationView.bounds.height,
+            let rect = CGRect(x: point.x - (annotationView.bounds.width / 2),
+                              y: point.y - (annotationView.bounds.height),
                               width: annotationView.bounds.width,
                               height: annotationView.bounds.height)
 

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleOpen/CapsuleOpenCoordinator.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleAccess/CapsuleOpen/CapsuleOpenCoordinator.swift
@@ -25,7 +25,7 @@ class CapsuleOpenCoordinator: Coordinator {
         }
         capsuleOpenViewModel.coordinator = self
         capsuleOpenViewController.viewModel = capsuleOpenViewModel
-
+        
         navigationController?.pushViewController(capsuleOpenViewController, animated: true)
     }
 
@@ -40,7 +40,7 @@ class CapsuleOpenCoordinator: Coordinator {
         guard let parent = parent as? CapsuleAccessCoordinator else {
             return
         }
-
+ 
         parent.moveToCapsuleDetail()
     }
 }

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListCoordinator.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleList/CapsuleListCoordinator.swift
@@ -22,15 +22,22 @@ final class CapsuleListCoordinator: Coordinator {
     }
 
     func start() {
+        moveToCapsuleList()
+    }
+    
+    func moveToCapsuleList() {
         let capsuleListViewController = CapsuleListViewController()
         let capsuleListViewModel = CapsuleListViewModel()
-
         capsuleListViewModel.coordinator = self
         capsuleListViewController.viewModel = capsuleListViewModel
         capsuleListViewModel.input.sortPolicy = sortPolicyObserver
         capsuleListViewController.viewModel?.input.sortPolicy = sortPolicyObserver
-
         navigationController?.setViewControllers([capsuleListViewController], animated: true)
+        
+        setUpNavigationItem()
+    }
+    
+    private func setUpNavigationItem() {
         navigationController?.navigationBar.topItem?.title = "목록"
         navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.themeFont(ofSize: FrameResource.fontSize120) as Any]
     }

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleMap/CapsuleMapViewController.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/CapsuleMap/CapsuleMapViewController.swift
@@ -12,7 +12,7 @@ import UIKit
 
 final class CapsuleMapViewController: UIViewController, BaseViewController {
     struct Settings {
-        static let openableRange: Double = 100
+        static let openableRange: Double = LocationManager.openableRange
         static let monitoringRange: Double = 1000
         static let monitoringUpdateRange: Double = 850
         static let locationUpdateRange: Double = 5


### PR DESCRIPTION
## 제출 전 필수 확인 사항:

- [X] Merge 하는 브랜치가 올바른가?
- [X] 코드 컨벤션을 준수하는가?
- [X] 빌드가 되는 코드인가요?
- [x] 버그가 발생하지 않는지 충분히 테스트 해봤나요?

## 작업 내용:
- 상세 화면 내 지도 annotation 중앙에 위치
- 지도 annotation 커스텀화
- 상세 화면 tab bar 업데이트

## 이번에 공들였던 부분:
- 지도 그리기

상세 화면 내 지도를 그릴 때 좌표값과 지도의 가로길이 두 데이터가 필요했습니다.
좌표값은 Model을 통해서 가져오고 가로 길이는 ViewController에서 `frame.width` 를 통해 계산하는 수밖에 없었습니다.

frameWidth와 mapCoordinate가 업데이트 되면 한 번에 데이터를 묶어서 지도를 그리는 `mapSnapshotInfo`라는 Observable을 만들어서 이 문제를 해결했습니다.

