### PR TITLE
[홈] 캡슐 순서를 랜덤에서 고정 순서로 변경

### DIFF
--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/Home/Components/HomeCapsuleCellItem.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/Home/Components/HomeCapsuleCellItem.swift
@@ -9,12 +9,12 @@ import UIKit
 import CoreLocation
 
 enum CapsuleType: CaseIterable {
-    case closedLongest
-    case closedShortest
-    case memoryOldest
-    case memoryNewest
     case nearest
     case farthest
+    case closedShortest
+    case closedLongest
+    case memoryNewest
+    case memoryOldest
     case leastOpened
     case mostOpened
     

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/Home/Components/HomeCapsuleCellItem.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/Home/Components/HomeCapsuleCellItem.swift
@@ -20,18 +20,18 @@ enum CapsuleType: CaseIterable {
     
     var title: String {
         switch self {
-        case .closedLongest:
-            return "밀봉한지 가장 오래된 캡슐"
-        case .closedShortest:
-            return "가장 최근에 생성한 캡슐"
-        case .memoryOldest:
-            return "가장 오래된 추억이 담긴 캡슐"
-        case .memoryNewest:
-            return "가장 최근 추억이 담긴 캡슐"
         case .nearest:
             return "가장 가까운 위치의 캡슐"
         case .farthest:
             return "가장 먼 위치의 캡슐"
+        case .closedShortest:
+            return "가장 최근에 생성한 캡슐"
+        case .closedLongest:
+            return "가장 오래전 생성한 캡슐"
+        case .memoryNewest:
+            return "가장 최근 추억이 담긴 캡슐"
+        case .memoryOldest:
+            return "가장 오랜 추억이 담긴 캡슐"
         case .leastOpened:
             return "열어본 횟수가 가장 적은 캡슐"
         case .mostOpened:

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/Home/HomeViewController.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/Home/HomeViewController.swift
@@ -27,7 +27,6 @@ final class HomeViewController: UIViewController, BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        configure()
         configureView()
         bind()
 
@@ -37,9 +36,6 @@ final class HomeViewController: UIViewController, BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         viewModel?.input.viewWillAppear.onNext(())
-    }
-    
-    private func configure() {
         AppDataManager.shared.fetchCapsules()
     }
     

--- a/SpaceCapsule/SpaceCapsule/Scene/TabBar/Home/HomeViewModel.swift
+++ b/SpaceCapsule/SpaceCapsule/Scene/TabBar/Home/HomeViewModel.swift
@@ -57,7 +57,7 @@ final class HomeViewModel: BaseViewModel, CapsuleCellNeedable {
                         return
                     }
                     owner.output.featuredCapsuleCellItems.accept(
-                        CapsuleType.allCases.shuffled()
+                        CapsuleType.allCases
                             .map { owner.getHomeCapsuleCellItem(capsules: capsuleList, type: $0) }
                             .compactMap({ $0 })
                     )


### PR DESCRIPTION
## 제출 전 필수 확인 사항:

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코드 컨벤션을 준수하는가?
- [x] 빌드가 되는 코드인가요?
- [x] 버그가 발생하지 않는지 충분히 테스트 해봤나요?

## 작업 내용:

- HomeViewModel : 랜덤으로 출력하지 않고 고정 순서로 출력하도록 변경
- HomeVC : 홈 화면에 돌아갈 때마다 매번 fetchCapsules하여 refresh 하도록
- CapsuleType의 title의 순서와 표현 변경

## 이번에 공들였던 부분:

- 홈 화면에 보이는 캡슐들의 순서를 고정하는 것이 좋다는 의견이 있었습니다.
- 따라서 캡슐들의 순서를 고정하도록 하였고, 우선 제 판단으로 순서를 정해보았습니다.
- 순서가 마음에 들지 않으면 함께 논의하여 순서를 조정하면 좋을 것 같습니다.
- 또한 캡슐 클릭하여 CapsuleAccess에 들어갔다가 그냥 나왔을 경우 refresh를 진행합니다.
- 따라서 실시간 정보에 가깝게 보여지도록 구현하였습니다.
